### PR TITLE
Add HubSpot to Official Integrations

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -45,6 +45,7 @@ These MCP servers are maintained by companies for their platforms:
 - **[BrowserStack](https://github.com/browserstack/mcp-server)** - Access BrowserStack's [Test Platform](https://www.browserstack.com/test-platform) to debug, write and fix tests, do accessibility testing and more.
 - **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy and manage resources on the Cloudflare developer platform
 - **[E2B](https://github.com/e2b-dev/mcp-server)** - Execute code in secure cloud sandboxes
+- **[HubSpot](https://developer.hubspot.com/mcp)** - Connect, manage, and interact with HubSpot CRM data
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
 - **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through Markdown notes in Obsidian vaults
 - **[Prisma](https://pris.ly/docs/mcp-server)** - Manage and interact with Prisma Postgres databases


### PR DESCRIPTION
[HubSpot](https://www.hubspot.com/) now has official MCP server managed through [NPM](https://www.npmjs.com/package/@hubspot/mcp-server)!
Here is the [Landing Page](https://developers.hubspot.com/mcp).
I am part of the engineering team maintaining it, happy to answer any questions. 